### PR TITLE
test(compose): update regression test to reflect gateway removal

### DIFF
--- a/tests/test_issue_137_python_compose_fixes.py
+++ b/tests/test_issue_137_python_compose_fixes.py
@@ -205,12 +205,21 @@ class TestComposeYamlValid:
             "websocket-server",
             "frontend-react",
             "nginx",
-            "gateway",
         ):
             assert required in services, (
                 f"docker-compose.python.yml is missing required service "
                 f"`{required}`."
             )
+
+    def test_gateway_service_absent(self):
+        """Issue #163: gateway container must be removed from docker-compose.python.yml.
+        All services in services/ are merged into the single 'backend' container."""
+        compose = load_compose()
+        assert "gateway" not in compose["services"], (
+            "docker-compose.python.yml must NOT contain a `gateway` service — "
+            "issue #163 requires all services/ microservices to be unified into "
+            "the single `backend` container."
+        )
 
 
 def _parse_duration(value):


### PR DESCRIPTION
## Summary

- Removes `gateway` from the list of required services in `test_required_services_present` (issue #163 removed the gateway container from `docker-compose.python.yml`)
- Adds `test_gateway_service_absent` to explicitly assert that `gateway` is NOT present, locking in the issue #163 requirement

## Context

PR #164 (merged) removed the `gateway` service from `docker-compose.python.yml` as required by issue #163, but the regression test in `tests/test_issue_137_python_compose_fixes.py` still expected `gateway` to be present. This caused `compose-regression-tests` CI to fail on both the PR and now on `main`.

## Test plan

- [ ] `compose-regression-tests` CI job passes
- [ ] All 14 tests in `test_issue_137_python_compose_fixes.py` pass (verified locally)